### PR TITLE
update printtoken formatting

### DIFF
--- a/src/blib2to3/pgen2/tokenize.py
+++ b/src/blib2to3/pgen2/tokenize.py
@@ -246,7 +246,7 @@ def printtoken(
     (srow, scol) = srow_col
     (erow, ecol) = erow_col
     print(
-        "%d,%d-%d,%d:\t%s\t%s" % (srow, scol, erow, ecol, tok_name[type], repr(token))
+        "%d,%d-%d,%d | %s | %s" % (srow, scol, erow, ecol, tok_name[type], repr(token))
     )
 
 

--- a/src/blib2to3/pgen2/tokenize.py
+++ b/src/blib2to3/pgen2/tokenize.py
@@ -246,7 +246,7 @@ def printtoken(
     (srow, scol) = srow_col
     (erow, ecol) = erow_col
     print(
-        "%d,%d-%d,%d | %s | %s" % (srow, scol, erow, ecol, tok_name[type], repr(token))
+        "%d,%d-%d,%d ; %s ; %s" % (srow, scol, erow, ecol, tok_name[type], repr(token))
     )
 
 


### PR DESCRIPTION
### Update printtoken formatting to use semicolon separators instead of tab characters in tokenize.py
Changes the output format of the `printtoken` function in [tokenize.py](https://github.com/PrassoTesting/black/pull/1/files#diff-5d607dde81ff6b739ddfe88751160fad2e93529494e8c27aacdbd8ebbea6e939) from using tab characters (`\t`) to semicolons with spaces (` ; `) as separators when displaying token information for testing purposes.

#### 📍Where to Start
Start with the `printtoken` function in [tokenize.py](https://github.com/PrassoTesting/black/pull/1/files#diff-5d607dde81ff6b739ddfe88751160fad2e93529494e8c27aacdbd8ebbea6e939).

----

_[Macroscope](https://primary.lb.app.staging.web.nonprod.prasso.ai) summarized c0b6c2f._